### PR TITLE
[HOTFIX] Update the Travis Setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ cache:
 after_success:
   - "curl -o /tmp/travis-automerge https://raw.githubusercontent.com/cdown/travis-automerge/master/travis-automerge"
   - "chmod a+x /tmp/travis-automerge"
-  - "BRANCHES_TO_MERGE_REGEX='^develop$' BRANCH_TO_MERGE_INTO=master GITHUB_REPO=cdown/srt /tmp/travis-automerge"
+  - "BRANCHES_TO_MERGE_REGEX='^develop$' BRANCH_TO_MERGE_INTO=master GITHUB_REPO=erunks/SmashCoachApi /tmp/travis-automerge"


### PR DESCRIPTION
### What
The Travis configs were trying to push to the wrong repo. This should fix that, and master should start to be updated automatically.

### Changes
- Updated the default value for the `GITHUB_REPO` env var from the guide to the correct repo

