### PR TITLE
Setup Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-server: node server.js
+worker: npm start

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "npm run lint:eslint -- . ",
     "lint:fix": "npm run lint:eslint -- . --fix",
     "lint:eslint": "eslint --ignore-path .gitignore",
-    "dev": "node -r dotenv/config server.js"
+    "dev": "node -r dotenv/config server.js",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
### What
The `server` worker wasn't being picked up from the `Procfile`, so we need to rename it to work. Also needed to setup the appropriate command for the worker to run.

### Changes
- Add a start command to run `node server.js`
- Add `worker` to run `npm start` command in `Procfile`